### PR TITLE
12: fragment view

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@radix-ui/react-dropdown-menu": "^2.1.15",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-slot": "^1.2.3",
+        "@radix-ui/react-tooltip": "^1.2.7",
         "@tanstack/react-query": "^5.83.0",
         "@trpc/client": "^11.4.3",
         "@trpc/server": "^11.4.3",
@@ -3965,6 +3966,40 @@
         }
       }
     },
+    "node_modules/@radix-ui/react-tooltip": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-tooltip/-/react-tooltip-1.2.7.tgz",
+      "integrity": "sha512-Ap+fNYwKTYJ9pzqW+Xe2HtMRbQ/EeWkj2qykZ6SuEV4iS/o1bZI5ssJbk4D2r8XuDuOBVz/tIx2JObtuqU+5Zw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.2",
+        "@radix-ui/react-compose-refs": "1.1.2",
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.10",
+        "@radix-ui/react-id": "1.1.1",
+        "@radix-ui/react-popper": "1.2.7",
+        "@radix-ui/react-portal": "1.1.9",
+        "@radix-ui/react-presence": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.3",
+        "@radix-ui/react-slot": "1.2.3",
+        "@radix-ui/react-use-controllable-state": "1.2.2",
+        "@radix-ui/react-visually-hidden": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@radix-ui/react-use-callback-ref": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.1.tgz",
@@ -4082,6 +4117,29 @@
       },
       "peerDependenciesMeta": {
         "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-visually-hidden": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-visually-hidden/-/react-visually-hidden-1.2.3.tgz",
+      "integrity": "sha512-pzJq12tEaaIhqjbzpCuv/OypJY/BPavOofm+dbab+MHLajy277+1lLm6JFcGgF5eskJ6mquGirhXY2GD/8u8Ug==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "@radix-ui/react-dropdown-menu": "^2.1.15",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-slot": "^1.2.3",
+    "@radix-ui/react-tooltip": "^1.2.7",
     "@tanstack/react-query": "^5.83.0",
     "@trpc/client": "^11.4.3",
     "@trpc/server": "^11.4.3",

--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -1,0 +1,23 @@
+"use client";
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+interface HintProps {
+  children: React.ReactNode;
+  text: string;
+  side?: "top" | "right" | "bottom" | "left";
+  align?: "start" | "center" | "end";
+}
+
+export const Hint = ({ children, text, side = "top", align = "center" }: HintProps) => {
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>{children}</TooltipTrigger>
+        <TooltipContent side={side} align={align}>
+          <p>{text}</p>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+};

--- a/src/components/ui/tooltip.tsx
+++ b/src/components/ui/tooltip.tsx
@@ -1,0 +1,61 @@
+"use client"
+
+import * as React from "react"
+import * as TooltipPrimitive from "@radix-ui/react-tooltip"
+
+import { cn } from "@/lib/utils"
+
+function TooltipProvider({
+  delayDuration = 0,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Provider>) {
+  return (
+    <TooltipPrimitive.Provider
+      data-slot="tooltip-provider"
+      delayDuration={delayDuration}
+      {...props}
+    />
+  )
+}
+
+function Tooltip({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Root>) {
+  return (
+    <TooltipProvider>
+      <TooltipPrimitive.Root data-slot="tooltip" {...props} />
+    </TooltipProvider>
+  )
+}
+
+function TooltipTrigger({
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Trigger>) {
+  return <TooltipPrimitive.Trigger data-slot="tooltip-trigger" {...props} />
+}
+
+function TooltipContent({
+  className,
+  sideOffset = 0,
+  children,
+  ...props
+}: React.ComponentProps<typeof TooltipPrimitive.Content>) {
+  return (
+    <TooltipPrimitive.Portal>
+      <TooltipPrimitive.Content
+        data-slot="tooltip-content"
+        sideOffset={sideOffset}
+        className={cn(
+          "bg-primary text-primary-foreground animate-in fade-in-0 zoom-in-95 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=closed]:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 z-50 w-fit origin-(--radix-tooltip-content-transform-origin) rounded-md px-3 py-1.5 text-xs text-balance",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <TooltipPrimitive.Arrow className="bg-primary fill-primary z-50 size-2.5 translate-y-[calc(-50%_-_2px)] rotate-45 rounded-[2px]" />
+      </TooltipPrimitive.Content>
+    </TooltipPrimitive.Portal>
+  )
+}
+
+export { Tooltip, TooltipTrigger, TooltipContent, TooltipProvider }

--- a/src/modules/projects/ui/components/fragment-web.tsx
+++ b/src/modules/projects/ui/components/fragment-web.tsx
@@ -1,0 +1,68 @@
+import { useState } from "react";
+import { Fragment } from "@/generated/prisma";
+import { ExternalLinkIcon, RefreshCcwIcon } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Hint } from "@/components/hint";
+
+interface Props {
+  data: Fragment;
+}
+
+const FragmentWeb = ({ data }: Props) => {
+  const [fragmentKey, setFragmentKey] = useState(0);
+  const [copied, setCopid] = useState(false);
+
+  const onRefresh = () => {
+    setFragmentKey((prev) => prev + 1);
+  };
+
+  const handleCopy = () => {
+    navigator.clipboard.writeText(data.sandboxeUrl);
+    setCopid(true);
+    setTimeout(() => setCopid(false), 2000);
+  };
+  return (
+    <div className="flex flex-col w-full h-full">
+      <div className="p-2 border-b bg-sidebar flex items-center gap-x-2">
+        <Hint text="Refresh">
+          <Button size="sm" variant="outline" onClick={onRefresh}>
+            <RefreshCcwIcon />
+          </Button>
+        </Hint>
+        <Hint text="Click to copy" side="bottom">
+          <Button
+            size="sm"
+            variant="outline"
+            onClick={handleCopy}
+            disabled={!data.sandboxeUrl || copied}
+            className="flex-1 justify-start text-start font-normal"
+          >
+            <span className="truncate">{data.sandboxeUrl}</span>
+          </Button>
+        </Hint>
+        <Hint text="Open in a new tab">
+          <Button
+            size="sm"
+            disabled={!data.sandboxeUrl}
+            variant="outline"
+            onClick={() => {
+              if (!data.sandboxeUrl) return;
+              window.open(data.sandboxeUrl, "_blank");
+            }}
+          >
+            <ExternalLinkIcon />
+          </Button>
+        </Hint>
+      </div>
+      <iframe
+        key={fragmentKey}
+        className="h-full w-full"
+        sandbox="allow-forms allow-scripts allow-same-origin"
+        loading="lazy"
+        src={data.sandboxeUrl}
+      />
+    </div>
+  );
+};
+
+export default FragmentWeb;

--- a/src/modules/projects/ui/views/project-view.tsx
+++ b/src/modules/projects/ui/views/project-view.tsx
@@ -5,6 +5,7 @@ import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from "@/componen
 import { MessagesContainer } from "../components/messages-container";
 import { Fragment } from "@/generated/prisma";
 import ProjectHeader from "../components/project-header";
+import FragmentWeb from "../components/fragment-web";
 
 interface Props {
   projectId: string;
@@ -29,7 +30,7 @@ const ProjectView = ({ projectId }: Props) => {
         </ResizablePanel>
         <ResizableHandle withHandle />
         <ResizablePanel defaultSize={65} minSize={50}>
-          TODO: Preview
+          {!!activeFragment && <FragmentWeb data={activeFragment} />}
         </ResizablePanel>
       </ResizablePanelGroup>
     </div>


### PR DESCRIPTION
- Introduced a reusable tooltip component for displaying contextual hints.
- Added a web fragment preview component with controls to refresh, copy, and open the preview in a new tab.
- Enabled live preview of project fragments directly within the project view, including interactive controls and tooltips.

<img width="1919" height="1032" alt="Screenshot 2025-08-11 170708" src="https://github.com/user-attachments/assets/b074f62f-2d29-44f6-bd26-7a7595d785e6" />